### PR TITLE
Apply GOV.UK style to speaker pack

### DIFF
--- a/app/views/speakerpack.html
+++ b/app/views/speakerpack.html
@@ -28,32 +28,27 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-				
-		<h1 class="govuk-heading-xl">Share your data story at DataConnect21</h1>
-		
+
+		<h1 class="govuk-heading-xl">DataConnect21 guide for speakers and session hosts</h1>
+
 		<img src="/public/images/DataConnect21_logo.png" alt="DataConnect Week 2021" width="30%" style="margin: 0 0 40px 50px;">
-		
-		<h1 class="govuk-heading-s"> 27 September to 1 October 2021, hosted by the Data Standards Authority and the Government Data Quality Hub</h1>
-   		
-		<h1 class="govuk-heading-m">Guide for Speakers and Session Hosts</h1>
-		<p><a href="/public/images/dc21-sessionpack.pdf"> Download this speaker pack as a PDF </a></p>
 
+		<p> 27 September to 1 October 2021. Hosted by the Data Standards Authority and the Government Data Quality Hub.</p>
 
-		<h1 class="govuk-heading-m">What is DataConnect21?</h1>
+		<p><a href="/public/images/dc21-sessionpack.pdf">Download this speaker guide as a PDF</a></p>
 
 		<p>DataConnect21 is a week-long festival of all things data across government, local government and the UK public sector, running from 27 September to 1 October 2021.</p>
 
-		<p>It is co-hosted by the Data Standards Authority, part of the Central Digital and Data Office in the Cabinet Office and the Government Data Quality Hub at the Office for National Statistics.</p>
+		<p>It's co-hosted by the Data Standards Authority (part of the Central Digital and Data Office at the Cabinet Office) and the Government Data Quality Hub at the Office for National Statistics.</p>
 
-		<p>Anyone and everyone in the UK public sector interested in data will come together online to tell and hear stories about data in government and reflect on the wider effect of better use of data is having across the whole of government.
-
+		<p>Anyone and everyone in the UK public sector interested in data will come together online to tell and hear stories about data in government and reflect on the wider effect that better use of data is having across the whole of government.
 
 		<h1 class="govuk-heading-m">Tell your story at DataConnect21</h1>
-		<p>You are invited to take part. You don’t need to be a data expert. We’re interested in hearing from a diverse range of people doing interesting work with data.</p>
+		<p>You're invited to take part. You do not need to be a data expert. We’re interested in hearing from a diverse range of people doing interesting work with data.</p>
 
 		<p>DataConnect21 is a unique opportunity for you to connect with a wide audience to share your team’s data stories and successes.</p>
 
-		<p>If you are outside of the UK public sector, we’re still keen to hear from you!</p>
+		<p>If you're outside the UK public sector, we’re still keen to hear from you.</p>
 
 		<p>If you've built a service or carried out research using publicly available public sector and government data, please share your story.</p>
 
@@ -61,47 +56,44 @@
 
 
 
-		<h1 class="govuk-heading-m">What’s in it for you?</h1>
-		<p>Run your own session or event as a host – join DWP Digital, Central Digital and Data Office, Office for National Statistics, Open Data Institute and many others already signed up to run sessions.</p>
+		<h1 class="govuk-heading-m">What’s in it for you</h1>
+		<p>Run your own session or event as a host, joining DWP Digital, Central Digital and Data Office, Office for National Statistics, Open Data Institute and many others who have already signed up to run sessions.</p>
 
 		<p>You’re welcome to contact the organisers at <a href="mailto:dataconnect21@digital.cabinet-office.gov.uk">dataconnect21@digital.cabinet-office.gov.uk</a> to talk through your ideas.</p>
 
-		<p>You’ll also find some ideas in this information pack.</p>
+		<p>If you host a session, DataConnect21 will connect you with people from across the public sector, central and local government – product owners, service delivery, operational and policy people as well as those from the digital, data and technology and analysis functions.</p>
 
-		<p>As a session host, DataConnect will connect you with people from across the public sector, central and Local Government – product owners, service delivery, operational and policy people as well as those from the digital, data and technology and analysis functions.</p>
+		<p>You’ll be in good company. The following are some of the organisations that will be taking part:<br><br>
+      <ul class="govuk-list govuk-list--bullet">
+		<li>DWP Digital</li>
+		<li>HM Revenue and Customs (HMRC)</li>
+		<li>Department for Business, Energy and Industrial Strategy (BEIS)</li>
+		<li>Department for International Trade (DIT)</li>
+		<li>NHS Digital</li>
+		<li>Ordnance Survey</li>
+    </ul>
 
-		<p>People passionate about how data can help deliver better public services.</p>
+		<h1 class="govuk-heading-m">The benefits to organisations of engaging with DataConnect21</h1>
 
-		<p>You’ll be in good company. Here’s some of the organisations that will be taking part:<br><br>
-
-		- DWP Digital<br>
-		- HM Revenue and Customs (HMRC)<br>
-		- Department for Business, Energy and Industrial Strategy (BEIS)<br>
-		- Department for International Trade (DIT)<br>
-		- NHS Digital<br>
-		- Ordnance Survey</p>
-
-		<h1 class="govuk-heading-m">The benefits to organisations of engaging with DataConnect21:</h1>
+    Joining us at this event will help your organisation:
 		 <ul class="govuk-list govuk-list--bullet">
-        <li>Showcase successes and promote collaboration around the opportunities that come from better use of data across the public sector, connecting this with direct benefits to citizens</li>
-		<li>Connect data/digital policy and technical teams across government, local government and the public sector</li>
-		<li>Incentivise better practice and help build data capability across government and support delivery of the National Data Strategy missions</li>
-		<li>Use learnings from the event to inform policy development and increase collaboration between data policy and practice specialists across government</li>
+        <li>showcase successes and promote collaboration around the opportunities that come from better use of data across the public sector, connecting this with direct benefits to citizens</li>
+		<li>connect data and digital policy and technical teams across government, local government and the public sector</li>
+		<li>incentivise better practice and help build data capability across government and support delivery of the National Data Strategy missions</li>
+		<li>use learnings from the event to inform policy development and increase collaboration between data policy and practice specialists across government</li>
 		</ul>
-		
-		<h1 class="govuk-heading-m">What’s the next step?</h1>
 
-		<h1 class="govuk-heading-s">Your next step is:</h1>
+		<h1 class="govuk-heading-m">Next steps for speakers</h1>
 
-		<p>Tell us the topic of your session and what day and time you’d like to run it  - email us at <a href="mailto:dataconnect21@digital.cabinet-office.gov.uk">dataconnect21@digital.cabinet-office.gov.uk</a> as soon as you can.</p>
+		<p>Tell us the topic of your session and what day and time you’d like to run it. Email us at <a href="mailto:dataconnect21@digital.cabinet-office.gov.uk">dataconnect21@digital.cabinet-office.gov.uk</a> as soon as you can.</p>
 
 		<p>The DataConnect21 organising team will get back to you within 3 working days to confirm we’ve received your session pledge.</p>
 
 		<p>Then you’ll need to:</p>
-		
+
 		<ul class="govuk-list govuk-list--bullet">
-        <li>plan the session. If you are running the session on your own – we can help, just email us</li>
-		<li>use whatever online meeting tech you have access to, to run your session - we’ll send you  info on accessibility and privacy as part of our support to you</li>
+        <li>plan the session - if you are running the session on your own, we can help if you email us</li>
+		<li>use online meeting tools to run your session - we’ll send you information on accessibility and privacy as part of our support to you</li>
 		<li>decide whether your session will be open to all or limited to a specific audience</li>
 		</ul>
 
@@ -109,16 +101,16 @@
 		<ul class="govuk-list govuk-list--bullet">
         <li>an open schedule where you can add your session at the day and time you choose</li>
 		<li>communications across government about the event, bringing a wide audience to your session</li>
-		<li>advice and support on accessibility, tech and session planning to help you get the best out of your session</li>
-		<li>open office hours to get advice, connect with other session hosts, test your tech. We’ll be your cheerleaders!</li>
+		<li>advice and support on accessibility, technology and session planning to help you get the best out of your session</li>
+		<li>open office hours to get advice, connect with other session hosts or test your setup</li>
 		</ul>
 
-		<h1 class="govuk-heading-m">Decide whether your session will be open or closed</h1>
+		<h2 class="govuk-heading-m">Decide whether your session will be open or closed</h2>
 
-		<p>This is something that you can choose, based on the content of your session. Please note that DataConnect will have a wide public sector and possibly private sector audience.</p>
+		<p>This is something that you can choose, based on the content of your session. Please note that DataConnect21 will have a wide public sector and possibly private sector audience.</p>
 
-		<p>Some people choose to share an open link (for example if you are using webinar software). Others chose to ask participants to email or register for the link so they can see who’s attending. Either way is fine and up to you.</p>
-		
+		<p>Some people choose to share an open link, for example when using webinar software. Others chose to ask participants to email or register for the link so they can see who’s attending. Either way is fine and up to you.</p>
+
 		<h1 class="govuk-heading-m">Stay connected with DataConnect21</h1>
 
 		<p>Sign up for our mailing list at <a href="mailto:dataconnect21@digital.cabinet-office.gov.uk">dataconnect21@digital.cabinet-office.gov.uk</a> to receive updates.</p>
@@ -127,29 +119,29 @@
 
 		<p>Join the conversation on LinkedIn, Twitter or Instagram with the hashtag #DataConnect21 and share our content with your followers.</p>
 
-		<p>Join the <a href="https://khub.net/group/dataconnect" target="new">Knowledge Hub</a> space for Local Government and public sector folk.</p>
+		<p>Join the <a href="https://khub.net/group/dataconnect" target="new">DataConnect21 group on Knowledge Hub</a> for local government and public sector people.</p>
 
 		<h1 class="govuk-heading-l">Ideas for session formats</h1>
 
-		<h1 class="govuk-heading-m">Show & Tells</h1>
+		<h1 class="govuk-heading-m">Show and tells</h1>
 
-		<p>Show & Tells happen in many places regularly. They are a great way to engage people with a product or service you are developing, or a new technique or platform you’ve found useful.</p>
+		<p>Show and tells are a great way to engage people with a product or service you're developing, or a new technique or platform you’ve found useful.</p>
 
-		<p>Ways to connect with DataConnect21:</p>
+		<p>You can connect with DataConnect21 in the following ways:</p>
 		<ul class="govuk-list govuk-list--bullet">
-        <li>Arrange a Show and Tell for a cross-government audience as part of our planned schedule for DataConnect21 week. You bring the topic, we’ll bring the audience!</li>
-        <li>Use the DataConnect21 backgrounds or logo with your planned Show & Tell talk</li>
+        <li>arrange a show and tell for a cross-government audience as part of our planned schedule for DataConnect21 week - you bring the topic, we’ll bring the audience</li>
+        <li>use the DataConnect21 backgrounds or logo with your planned show and tell talk</li>
         </ul>
 
-		<h1 class="govuk-heading-m">Community Meetups</h1>
+		<h1 class="govuk-heading-m">Community meetups</h1>
 
 		<p>Meetups are a great way to discuss the opportunities and challenges with data across government.</p>
 
-		<p>Ways to connect with DataConnect21:
+		<p>You can connect with DataConnect21 in the following ways:</p>
 		<ul class="govuk-list govuk-list--bullet">
-        <li>Sign up for our mailing list to find out about meetups taking place during DataConnect21.</li>
-        <li>Arrange a meetup of networks you are a part of during DataConnect21 week and let us know.</li>
-		<li>Organise a discussion for a cross-government audience as part of our planned schedule for DataConnect21 week. You set the topic, we’ll bring the people!</li>
+        <li>sign up for our mailing list to find out about meetups taking place during DataConnect21</li>
+        <li>arrange a meetup of networks you're a part of during DataConnect21 week and let us know</li>
+		<li>organise a discussion for a cross-government audience as part of our planned schedule for DataConnect21 week - you set the topic, we’ll bring the people</li>
 		</ul>
 
 
@@ -160,35 +152,32 @@
 		Are you a developer who has set up an API instance in super-quick time?<br>
 		Can you explain why a data model is useful to a non-technical audience?</p>
 
-		<p>Share your skills and knowledge with DataConnect21:
-		<ul class="govuk-list govuk-list--bullet">
-        <li>Run a short workshop or skillshare session during DataConnect21 week, using our backgrounds and logo. You set up the session, we’ll bring the participants!</li>
-		</ul>
+		<p>Share your skills and knowledge with DataConnect21 by running a short workshop or skillshare session during DataConnect21 week, using our backgrounds and logo. You set up the session, we’ll bring the participants.</p>
 
-		<h1 class="govuk-heading-m">Presenting a case study or data story</h1>
+		<h1 class="govuk-heading-m">Present a case study or data story</h1>
 
 		<p>Case studies and storytelling are a great way to share learning across government.</p>
 
-		<p>Ways to connect with DataConnect21:</p>
+		<p>You can connect with DataConnect21 in the following ways:</p>
 		<ul class="govuk-list govuk-list--bullet">
-        <li>Contact us to find out about case study and storytelling sessions taking place during DataConnect21.</li>
-        <li>Arrange to tell the story of your team’s work to the rest of your organisation.</li>
-        <li>Organise a case study session as part of our open schedule for DataConnect21 week. You set the topic, we’ll bring the people!</li>
+        <li>contact us to find out about case study and storytelling sessions taking place during DataConnect21</li>
+        <li>arrange to tell the story of your team’s work to the rest of your organisation</li>
+        <li>organise a case study session as part of our open schedule for DataConnect21 week - you set the topic, we’ll bring the people</li>
         </ul>
 
 		<h1 class="govuk-heading-m">Write or record a post and share it with us</h1>
 
-		<p>If you enjoy following data folk on social media, why not take the leap and write / record / share your own data story on the social media platform of your choice during DataConnect21?</p>
+		<p>If you enjoy following data people on social media, why not take the leap and write, record or share your own data story on the social media platform of your choice during DataConnect21?</p>
 
-		<p>Writing about what you’ve learnt, or your work around data is a great way to reflect on it and share your learnings with others.</p>
+		<p>Writing about what you’ve learnt or your work around data is a great way to reflect on it and share your learnings with others.</p>
 
-		<p>If you share your story with us, we’ll help promote it via social media and may even invite you to share it as a GOV.UK blog post.</p>
+		<p>If you share your story with us, we’ll help promote it via social media and might even invite you to share it as a CDDO blog post.</p>
 
-		<p>3 ways to connect with DataConnect21 on social media using the tag #DataConnect21:</p>
+		<p>You can connect with DataConnect21 on social media using the tag #DataConnect21 by:</p>
 		<ul class="govuk-list govuk-list--bullet">
-        <li>share your story on LinkedIn, Instagram and Twitter or other social media platform.</li>
-		<li>Like and repost other people’s stories.</li>
-		<li>If you’re in a network of data folk, encourage others to share their story or create a joint story and share on your favourite social platform.</li>
+        <li>sharing your story on LinkedIn, Instagram and Twitter or other social media platform</li>
+		<li>liking and repost other people’s stories</li>
+		<li>if you’re in a network of data people, encourage others to share their story or create a joint story and share on your favourite social platform</li>
 		</ul>
 
 
@@ -200,26 +189,23 @@
 		<p>Contact us:</p>
 		<ul class="govuk-list govuk-list--bullet">
         <li>by email at <a href="mailto:dataconnect21@digital.cabinet-office.gov.uk">dataconnect21@digital.cabinet-office.gov.uk</a></li>
-		<li>on Knowledge Hub – the space for Local Government and public sector folk</li>
+		<li>on Knowledge Hub – the space for local government and public sector people</li>
 		</ul>
 
-		<p>This event is organised by:</p>
+		<p>This event is organised by the <a href="https://www.gov.uk/government/groups/data-standards-authority">Data Standards Authority</a>) and the <a href="https://www.gov.uk/government/organisations/government-data-quality-hub">Government Data Quality Hub</a>)</p>
 
-		<p><b>The Data Standards Authority, Central and Digital Data Office:<br><a href="mailto:data-standards-authority@digital.cabinet-office.gov.uk">data-standards-authority@digital.cabinet-office.gov.uk</a></b><br>
-		<b>Government Data Quality Hub: <a href="mailto:DQHub@ons.gov.uk">DQHub@ons.gov.uk</a></b></p>
 
-		<p>Last update 14 July 2021</p>
-      
 
-	
+
+
       <a href="https://www.smartsurvey.co.uk/s/FMR7RF/" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
-        Sign up here
+        Sign up
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
         </svg>
       </a>
 
-  
+
     </div>
 
     <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
More detailed updates to meet GOV.UK style, including:
- improved link accessibility
- general style and tone
- removed last updated
- changed CTA to "Sign up" (removed "here")

I also fixed a few formatting things that maybe got messed up when converting from markdown:
- fixed some lists to use proper bullet points
- fixed some odd header styling