### PR TITLE
Replaced Smart Surveys link with Eventbrite link

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -52,7 +52,7 @@
       </a> -->
 
 	
-      <a href="https://surveys.publishing.service.gov.uk/s/JSKN0Y/" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+      <a href="https://www.eventbrite.co.uk/e/dataconnect21-registration-166632258571" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
         Join our mailing list
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>


### PR DESCRIPTION
Replaced the Smart Surveys link under the button with the Eventbrite link. In terms of accessibility, I've read that Eventbrite works well with Jaws on Chrome (screen reader) so hopefully provides a good experience but one to keep an eye on. 